### PR TITLE
Add Support for Gitalk & Fix something

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -15,10 +15,10 @@ images: images
 
 # themes/shoka/source/images/***
 favicon:
-  apple_touch_icon: /apple-touch-icon.png
-  #safari_pinned_tab: /logo.svg
-  #android_manifest: /manifest.json
-  #ms_browserconfig: /browserconfig.xml
+  # apple_touch_icon: /apple-touch-icon.png
+  # safari_pinned_tab: /logo.svg
+  # android_manifest: /manifest.json
+  # ms_browserconfig: /browserconfig.xml
 
 # Dark Mode
 # By default, the page judges whether to turn on the dark mode according to the device settings or user selection
@@ -105,20 +105,20 @@ menu:
 # Value before `||` delimiter is the target permalink,
 # secend value is the name of Font icon.
 social:
-  github: https://github.com/yourname || github || "#191717"
-  #google: https://plus.google.com/yourname || google
-  twitter: https://twitter.com/yourname || twitter || "#00aff0"
-  zhihu: https://www.zhihu.com/people/yourname || zhihu || "#1e88e5"
-  music: https://music.163.com/#/user/home?id=yourid || cloud-music || "#e60026"
-  weibo: https://weibo.com/yourname || weibo || "#ea716e"
-  about: https://about.me/yourname || address-card || "#3b5998"
-  #email: mailto:yourname@mail.com || envelope || "#55acd5"
-  #facebook: https://www.facebook.com/yourname || facebook
-  #stackoverflow: https://stackoverflow.com/yourname || stack-overflow
-  #youtube: https://youtube.com/yourname || youtube
-  #instagram: https://instagram.com/yourname || instagram
-  #skype: skype:yourname?call|chat || skype
-  #douban: https://www.douban.com/people/yourname/ || douban
+  # github: https://github.com/yourname || github || "#191717"
+  # google: https://plus.google.com/yourname || google
+  # twitter: https://twitter.com/yourname || twitter || "#00aff0"
+  # zhihu: https://www.zhihu.com/people/yourname || zhihu || "#1e88e5"
+  # music: https://music.163.com/#/user/home?id=yourid || cloud-music || "#e60026"
+  # weibo: https://weibo.com/yourname || weibo || "#ea716e"
+  # about: https://about.me/yourname || address-card || "#3b5998"
+  # email: mailto:yourname@mail.com || envelope || "#55acd5"
+  # facebook: https://www.facebook.com/yourname || facebook
+  # stackoverflow: https://stackoverflow.com/yourname || stack-overflow
+  # youtube: https://youtube.com/yourname || youtube
+  # instagram: https://instagram.com/yourname || instagram
+  # skype: skype:yourname?call|chat || skype
+  # douban: https://www.douban.com/people/yourname/ || douban
 
 sidebar:
   # Sidebar Position.
@@ -153,9 +153,9 @@ reward:
   # If true, reward will be displayed in every article by default.
   enable: true
   account:
-    wechatpay: /wechatpay.png
-    alipay: /alipay.png
-    paypal: /paypal.png
+    # wechatpay: /wechatpay.png
+    # alipay: /alipay.png
+    # paypal: /paypal.png
 
 # TagCloud settings for tags page.
 tagcloud:
@@ -212,6 +212,18 @@ valine:
       # - hash of friend2@email.com
     investor:
       # - hash of investor1@email.com
+
+# Gitalk
+# For more information: https://github.com/gitalk/gitalk
+gitalk:
+  clientID: # GitHub Application Client ID.
+  clientSecret: # GitHub Application Client Secret.
+  repo: # GitHub repository.
+  owner: # GitHub repository owner. Can be personal user or organization.
+  admin: 
+    # GitHub repository owner and collaborators. (Users who having write access to this repository)
+    # - Username
+  createIssueManually: false # By default, Gitalk will create a corresponding github issue for your every single page automatically when the logined user is belong to the admin users. You can create it manually by setting this option to true.
 
 # bgm
 audio:
@@ -288,6 +300,7 @@ vendors:
     katex: npm/katex@0.12.0/dist/katex.min.css
     comment: css/comment.css
     fancybox: combine/npm/@fancyapps/fancybox@3.5.7/dist/jquery.fancybox.min.css,npm/justifiedGallery@3.8.1/dist/css/justifiedGallery.min.css
+    gitalk: npm/gitalk@1/dist/gitalk.css
   js:
     pace: npm/pace-js@1.0.2/pace.min.js
     pjax: npm/pjax@0.2.8/pjax.min.js
@@ -301,3 +314,4 @@ vendors:
     valine: gh/amehime/MiniValine@4.2.2-beta10/dist/MiniValine.min.js
     copy_tex: npm/katex@0.12.0/dist/contrib/copy-tex.min.js
     chart: npm/frappe-charts@1.5.0/dist/frappe-charts.min.iife.min.js
+    gitalk: npm/gitalk@1/dist/gitalk.min.js

--- a/example/_config.shoka.yml
+++ b/example/_config.shoka.yml
@@ -67,6 +67,18 @@ valine:
     friend:
       - deea5a8d259d17182a53be1772e4c182
 
+# Gitalk
+# For more information: https://github.com/gitalk/gitalk
+gitalk:
+  clientID: # GitHub Application Client ID.
+  clientSecret: # GitHub Application Client Secret.
+  repo: # GitHub repository.
+  owner: # GitHub repository owner. Can be personal user or organization.
+  admin: 
+    # GitHub repository owner and collaborators. (Users who having write access to this repository)
+    # - Username
+  createIssueManually: false # By default, Gitalk will create a corresponding github issue for your every single page automatically when the logined user is belong to the admin users. You can create it manually by setting this option to true.
+
 # bgm
 audio:
    - title: 列表1

--- a/layout/_macro/comment.njk
+++ b/layout/_macro/comment.njk
@@ -1,5 +1,9 @@
 {% macro render() %}
 {%- if page.comment !== false %}
-  <div class="wrap" id="comments"></div>
+    <div class="wrap" id="comments">
+      {%- if theme.gitalk.clientID and theme.gitalk.clientSecret and theme.gitalk.repo and theme.gitalk.owner %}
+        <div id="gitalk-container"></div>
+      {% endif %}
+    </div>
 {%- endif %}
 {% endmacro %}

--- a/layout/_macro/segment.njk
+++ b/layout/_macro/segment.njk
@@ -3,10 +3,12 @@
   {%- set postTitleIcon = '<i class="ic i-link-alt"></i>' %}
 {%- endif %}
 {%- set postText = item.title or item.link or __('post.untitled') %}
-<article class="item">
-  <div class="cover">
-    {{ _url(item.link or item.path, '<img data-src="'+ _cover(item) +'">', {itemprop: 'url', title: postText}) }}
-  </div>
+<article class="item {% if item.cover %}withcover{% endif %}">
+  {% if item.cover %}
+    <div class="cover">
+      {{ _url(item.link or item.path, '<img data-src="'+ _cover(item) +'">', {itemprop: 'url', title: postText}) }}
+    </div>
+  {% endif %}
   <div class="info">
     {{postmeta.render(item)}}
     <h3>{{ _url(item.link or item.path, postText + (postTitleIcon or ''), {itemprop: 'url', title: postText}) }}</h3>

--- a/layout/_macro/segment.njk
+++ b/layout/_macro/segment.njk
@@ -3,10 +3,10 @@
   {%- set postTitleIcon = '<i class="ic i-link-alt"></i>' %}
 {%- endif %}
 {%- set postText = item.title or item.link or __('post.untitled') %}
-  <article class="item">
-    <div class="cover">
-      {{ _url(item.link or item.path, '<img data-src="'+ _cover(item) +'">', {itemprop: 'url', title: postText}) }}
-    </div>
+<article class="item">
+  <div class="cover">
+    {{ _url(item.link or item.path, '<img data-src="'+ _cover(item) +'">', {itemprop: 'url', title: postText}) }}
+  </div>
   <div class="info">
     {{postmeta.render(item)}}
     <h3>{{ _url(item.link or item.path, postText + (postTitleIcon or ''), {itemprop: 'url', title: postText}) }}</h3>

--- a/layout/_macro/segment.njk
+++ b/layout/_macro/segment.njk
@@ -3,12 +3,10 @@
   {%- set postTitleIcon = '<i class="ic i-link-alt"></i>' %}
 {%- endif %}
 {%- set postText = item.title or item.link or __('post.untitled') %}
-<article class="item {% if item.cover %}withcover{% endif %}">
-  {% if item.cover %}
+  <article class="item">
     <div class="cover">
       {{ _url(item.link or item.path, '<img data-src="'+ _cover(item) +'">', {itemprop: 'url', title: postText}) }}
     </div>
-  {% endif %}
   <div class="info">
     {{postmeta.render(item)}}
     <h3>{{ _url(item.link or item.path, postText + (postTitleIcon or ''), {itemprop: 'url', title: postText}) }}</h3>

--- a/layout/_partials/layout.njk
+++ b/layout/_partials/layout.njk
@@ -7,7 +7,7 @@
 <head>
   {{ partial('_partials/head/head.njk', {}, {cache: true}) }}
   {{ partial('_partials/head/head_unique.njk') }}
-  <title>{% block title %}{% endblock %}{{ alternate + " = " if alternate }}{{ title }}{{ " = "+subtitle if subtitle }}</title>
+  <title>{% block title %}{% endblock %}{{ alternate + " = " if alternate }}{{ title }}{{ " = " + subtitle if subtitle }}</title>
 </head>
 <body itemscope itemtype="http://schema.org/WebPage">
   <div id="loading">
@@ -108,7 +108,8 @@
       stats: "{{ __('search.stats') }}"
     },
     {%- if theme.widgets.recent_comments or page.comment !== false  %}
-    valine: {{ page.valine|safedump if page.valine else "true"  }},{%- endif %}
+    valine: {{ page.valine|safedump if page.valine else "true"  }},
+    gitalk: {{ page.gitalk|safedump if page.gitalk else "true"  }},{%- endif %}
     {%- if page.chart %}chart: true,{%- endif %}
     {%- if page.math %}copy_tex: true,
     katex: true,{%- endif %}

--- a/layout/_partials/layout.njk
+++ b/layout/_partials/layout.njk
@@ -138,7 +138,7 @@
   };
 </script>
 
-<script src="https://cdn.polyfill.io/v2/polyfill.js"></script>
+<script src="https://polyfill.alicdn.com/polyfill.min.js"></script>
 
 {{ _vendor_js() }}
 

--- a/layout/archive.njk
+++ b/layout/archive.njk
@@ -25,9 +25,9 @@
   <div class="collapse wrap">
     <h2 class="item header">
         {%- if is_month() %}
-          <a href="{{ url_for(config.archive_dir) }}">{{ __('title.all') }}</a> <small>/</small> <a href="{{ url_for(config.archive_dir + '/' + page.year )}}">{{page.year}} {{__('symbol.year')}}</a> <small>/</small> {{page.month}} {{__('symbol.month')}}<small>{{ __('title.archive') }}</small>
+          <a href="{{ url_for(config.archive_dir + '/') }}">{{ __('title.all') }}</a> <small>/</small> <a href="{{ url_for(config.archive_dir + '/' + page.year + '/')}}">{{page.year}} {{__('symbol.year')}}</a> <small>/</small> {{page.month}} {{__('symbol.month')}}<small>{{ __('title.archive') }}</small>
         {% elif is_year() %}
-          <a href="{{ url_for(config.archive_dir) }}">{{ __('title.all') }}</a> <small>/</small> {{page.year}} {{__('symbol.year')}} <small>{{ __('title.archive') }}</small>
+          <a href="{{ url_for(config.archive_dir + '/') }}">{{ __('title.all') }}</a> <small>/</small> {{page.year}} {{__('symbol.year')}} <small>{{ __('title.archive') }}</small>
         {% else %}
           <a href="{{ url_for(site.path) }}">{{ __('menu.home') }}</a> <small>/</small>
           {%- set posts_length = site.posts.length %}
@@ -67,7 +67,7 @@
           {%- endif %}
 
           <h3 class="item section">
-            <a href="{{ url_for(config.archive_dir + '/' + year )}}">{{ year }} {{__('symbol.year')}}</a><small>/</small><a href="{{ url_for(config.archive_dir + '/' + year  + '/' + month)}}">{{ month }} {{__('symbol.month')}}</a>
+            <a href="{{ url_for(config.archive_dir + '/' + year + '/')}}">{{ year }} {{__('symbol.year')}}</a><small>/</small><a href="{{ url_for(config.archive_dir + '/' + year  + '/' + month + '/')}}">{{ month }} {{__('symbol.month')}}</a>
           {%- set current_year = year %}
           {%- set current_month = month %}
           {%- set count_post = 1 %}
@@ -79,12 +79,12 @@
 
         {%- if year !== current_year and not is_year()%}
           {%- set current_year = year %}
-          <h3 class="item section"><a href="{{ url_for(config.archive_dir + '/' + year )}}">{{ year }} {{__('symbol.year')}}</a></h3>
+          <h3 class="item section"><a href="{{ url_for(config.archive_dir + '/' + year + '/')}}">{{ year }} {{__('symbol.year')}}</a></h3>
         {%- endif %}
 
         {%- if month !== current_month and is_year() and not is_month()%}
           {%- set current_month = month %}
-          <h3 class="item section"><a href="{{ url_for(config.archive_dir + '/' + year  + '/' + month)}}">{{ month }} {{__('symbol.month')}}</a></h3>
+          <h3 class="item section"><a href="{{ url_for(config.archive_dir + '/' + year  + '/' + month + '/')}}">{{ month }} {{__('symbol.month')}}</a></h3>
         {%- endif %}
 
         <article class="item normal" itemscope itemtype="http://schema.org/Article">

--- a/layout/tag.njk
+++ b/layout/tag.njk
@@ -11,7 +11,7 @@
 {% block content %}
   <div class="collapse wrap">
     <h2 class="item header">
-      <a href="{{ url_for(config.tag_dir) }}">{{ __('title.all') }}</a>
+      <a href="{{ url_for(config.tag_dir + '/') }}">{{ __('title.all') }}</a>
       <small>/</small>
       {{ page.tag }}
       <small>{{ __('title.tag') }}</small>

--- a/scripts/filters/locals.js
+++ b/scripts/filters/locals.js
@@ -26,7 +26,9 @@ hexo.extend.filter.register('template_locals', locals => {
   locals.title = pangu.spacing(__('title') !== 'title' ? __('title') : config.title);
   locals.subtitle = pangu.spacing(__('subtitle') !== 'subtitle' ? __('subtitle') : config.subtitle);
   locals.author = __('author') !== 'author' ? __('author') : config.author;
-  locals.description = pangu.spacing(__('description') !== 'description' ? __('description') : config.description);
+  if(locals.description) {
+    locals.description = pangu.spacing(__('description') !== 'description' ? __('description') : config.description);
+  }
   locals.languages = [...i18n.languages];
   locals.languages.splice(locals.languages.indexOf('default'), 1);
   locals.page.lang = locals.page.lang || locals.page.language;

--- a/scripts/generaters/config.js
+++ b/scripts/generaters/config.js
@@ -38,6 +38,6 @@ hexo.extend.filter.register('before_generate', () => {
   if (data.images && data.images.length > 6) {
     hexo.theme.config.image_list = data.images
   } else {
-    hexo.theme.config.image_list = yaml.safeLoad(fs.readFileSync(path.join(__dirname, '../../_images.yml')))
+    hexo.theme.config.image_list = yaml.load(fs.readFileSync(path.join(__dirname, '../../_images.yml')))
   }
 })

--- a/scripts/generaters/script.js
+++ b/scripts/generaters/script.js
@@ -22,12 +22,14 @@ hexo.extend.generator.register('script', function(locals){
     auto_scroll: theme.auto_scroll,
     js: {
       valine: theme.vendors.js.valine,
+      gitalk: theme.vendors.js.gitalk,
       chart: theme.vendors.js.chart,
       copy_tex: theme.vendors.js.copy_tex,
       fancybox: theme.vendors.js.fancybox
     },
     css: {
       valine: theme.css + "/comment.css",
+      gitalk: theme.vendors.css.gitalk,
       katex: theme.vendors.css.katex,
       mermaid: theme.css + "/mermaid.css",
       fancybox: theme.vendors.css.fancybox
@@ -35,6 +37,7 @@ hexo.extend.generator.register('script', function(locals){
     loader: theme.loader,
     search : null,
     valine: theme.valine,
+    gitalk: theme.gitalk,
     quicklink: {
       timeout : theme.quicklink.timeout,
       priority: theme.quicklink.priority

--- a/scripts/helpers/asset.js
+++ b/scripts/helpers/asset.js
@@ -20,7 +20,7 @@ hexo.extend.helper.register('_vendor_font', () => {
   const fontDisplay = '&display=swap';
   const fontSubset = '&subset=latin,latin-ext';
   const fontStyles = ':300,300italic,400,400italic,700,700italic';
-  const fontHost = '//fonts.loli.net/css?family=Open+Sans';
+  const fontHost = '//fonts.dogedoge.com';
 
   //Get a font list from config
   let fontFamilies = ['global', 'logo', 'title', 'headings', 'posts', 'codes'].map(item => {

--- a/scripts/helpers/asset.js
+++ b/scripts/helpers/asset.js
@@ -20,7 +20,7 @@ hexo.extend.helper.register('_vendor_font', () => {
   const fontDisplay = '&display=swap';
   const fontSubset = '&subset=latin,latin-ext';
   const fontStyles = ':300,300italic,400,400italic,700,700italic';
-  const fontHost = '//fonts.googleapis.com';
+  const fontHost = '//fonts.loli.net/css?family=Open+Sans';
 
   //Get a font list from config
   let fontFamilies = ['global', 'logo', 'title', 'headings', 'posts', 'codes'].map(item => {

--- a/scripts/tags/links.js
+++ b/scripts/tags/links.js
@@ -40,7 +40,7 @@ function linkGrid(args, content) {
 
   const siteHost = url.parse(hexo.config.url).hostname || hexo.config.url;
 
-  const list = yaml.safeLoad(content);
+  const list = yaml.load(content);
 
   var result = ''
 

--- a/scripts/tags/media.js
+++ b/scripts/tags/media.js
@@ -7,7 +7,7 @@ function postMedia(args, content) {
   if(!args[0] || !content) {
     return
   }
-  const list = yaml.safeLoad(content);
+  const list = yaml.load(colntent);
   switch(args[0]) {
     case 'video':
     case 'audio':

--- a/source/css/_common/components/third-party/gitalk.styl
+++ b/source/css/_common/components/third-party/gitalk.styl
@@ -1,0 +1,3 @@
+#gitalk-container {
+	margin: 0 2rem;
+}

--- a/source/css/comment.styl
+++ b/source/css/comment.styl
@@ -3,3 +3,4 @@
 @import "_mixins.styl";
 
 @import "_common/components/third-party/valine";
+@import "_common/components/third-party/gitalk";

--- a/source/js/_app/pjax.js
+++ b/source/js/_app/pjax.js
@@ -55,21 +55,43 @@ const siteRefresh = function (reload) {
   vendorJs('copy_tex');
   vendorCss('mermaid');
   vendorJs('chart');
-  vendorJs('valine', function() {
-    var options = Object.assign({}, CONFIG.valine);
-    options = Object.assign(options, LOCAL.valine||{});
-    options.el = '#comments';
-    options.pathname = LOCAL.path;
-    options.pjax = pjax;
-    options.lazyload = lazyload;
 
-    new MiniValine(options);
+  if(CONFIG.valine.appId && CONFIG.valine.appKey) {
+    vendorJs('valine', function() {
+      var options = Object.assign({}, CONFIG.valine);
+      options = Object.assign(options, LOCAL.valine||{});
+      options.el = '#comments';
+      options.pathname = LOCAL.path;
+      options.pjax = pjax;
+      options.lazyload = lazyload;
 
-    setTimeout(function(){
-      positionInit(1);
-      postFancybox('.v');
-    }, 1000);
-  }, window.MiniValine);
+      new MiniValine(options);
+
+      setTimeout(function(){
+        positionInit(1);
+        postFancybox('.v');
+      }, 1000);
+    }, window.MiniValine);
+  }
+
+  if(CONFIG.gitalk.clientID && CONFIG.gitalk.clientSecret && CONFIG.gitalk.repo && CONFIG.gitalk.owner && CONFIG.gitalk.admin) {
+    vendorJs('gitalk', function() {
+      var options = Object.assign({}, CONFIG.gitalk);
+      options = Object.assign(options, LOCAL.gitalk||{});
+      options.pjax = pjax;
+      options.id = "/" + LOCAL.path;
+
+      const observer = lozad('#gitalk-container', {
+        load: function(el) {
+          var gitalk = new Gitalk(options);
+          gitalk.render('gitalk-container');
+        }
+      })
+      observer.observe();
+
+    }, window.Gitalk);
+    vendorCss('gitalk');
+  }
 
   if(!reload) {
     $.each('script[data-pjax]', pjaxScript);


### PR DESCRIPTION
新增：

- 添加了对 [Gitalk](https://github.com/gitalk/gitalk) 的支持，支持 lazyload。

  为了避免 Gitalk 与 Valine 冲突，我对涉及到 Valine 的 `comment.njk` 和 `pjax.js` 做了一些修改，但我现在没有使用 Valine 不方便测试，**建议合并前测试一下 Valine 的可用性**。

修复 / 优化：

- 修复 `<root>/_config.yml` 中 `description` 为空时 `pangu` 报错 `spacing(text) only accepts string but got object` 的问题。
- Polyfill.js 换为 v3 版本，引用了带有 `.min` 后缀的压缩资源。#8
  更换为 Alicdn 的镜像 <https://polyfill.alicdn.com/polyfill.min.js>。(Suggested by @SerokSSR)
- ~~Google Fonts 源换为了 [loli.net 的反代加速资源](https://sb.sb/blog/css-cdn/)。~~
  更换为基于 Tencent CDN 的镜像源 <https://fonts.dogedoge.com>。(Suggested by @SerokSSR)
- 注释掉 `<theme>/_config.yml` 的部分配置，以便不需要这些功能的用户不需要修改 `<theme>/_config.yml`。需要这些功能的用户可自行在 `<root>/_config.shoka.yml` 中配置。

_（另外大佬的主题真的太好看了！）_

