### PR TITLE
Fix incompatibility with Hexo 5.4

### DIFF
--- a/scripts/generaters/config.js
+++ b/scripts/generaters/config.js
@@ -38,6 +38,6 @@ hexo.extend.filter.register('before_generate', () => {
   if (data.images && data.images.length > 6) {
     hexo.theme.config.image_list = data.images
   } else {
-    hexo.theme.config.image_list = yaml.safeLoad(fs.readFileSync(path.join(__dirname, '../../_images.yml')))
+    hexo.theme.config.image_list = yaml.load(fs.readFileSync(path.join(__dirname, '../../_images.yml')))
   }
 })

--- a/scripts/tags/links.js
+++ b/scripts/tags/links.js
@@ -40,7 +40,7 @@ function linkGrid(args, content) {
 
   const siteHost = url.parse(hexo.config.url).hostname || hexo.config.url;
 
-  const list = yaml.safeLoad(content);
+  const list = yaml.load(content);
 
   var result = ''
 

--- a/scripts/tags/media.js
+++ b/scripts/tags/media.js
@@ -7,7 +7,7 @@ function postMedia(args, content) {
   if(!args[0] || !content) {
     return
   }
-  const list = yaml.safeLoad(content);
+  const list = yaml.load(colntent);
   switch(args[0]) {
     case 'video':
     case 'audio':


### PR DESCRIPTION
Function `yaml.safeLoad` has been not supported since Hexo 5.4.

> ```
> err: Error: Function yaml.safeLoad is removed in js-yaml 4. Use yaml.load instead, which is now safe by default.
> ```

Use `yaml.load` instead.

ref: https://blog.csdn.net/weixin_45149481/article/details/116609116