### PR TITLE
分类展示图片

### DIFF
--- a/py_scripts/add_hyphen_for_image_url.py
+++ b/py_scripts/add_hyphen_for_image_url.py
@@ -1,0 +1,48 @@
+import sys
+import os
+
+
+def read_file(file_path):
+    f = open(file_path, "rb")
+    content = f.read().decode('utf-8')
+    f.close()
+    return content
+
+
+def add_hyphen(file, image_content, day):
+    image_list = image_content.split('\r\n')
+    image_hyphen_content = "# " + file + "\r\n"
+    for image in image_list:
+        image_hyphen_content += "- " + str(day) + image + "\r\n"
+    image_hyphen_content += "\r\n"
+    return image_hyphen_content
+
+
+def write_file(image_yml_file_path, image_content):
+    f = open(image_yml_file_path, "ab")
+    f.write(bytes(image_content, 'utf-8'))
+    f.close()
+
+
+def main(image_host_data_path):
+    image_host_walk = os.walk(image_host_data_path + "\\image_host")
+    for root, directories, files in image_host_walk:
+        day = 1
+        for file in files:
+            image_content = read_file(root + "\\" + file)
+            image_content = add_hyphen(file, image_content, day)
+            write_file(image_host_data_path + "\\images.yml", image_content)
+            day += 1
+
+
+def usage():
+    print("\nusage: python add_hyphen_for_image_url.py image_host_data_path\n\n"
+          "eg:\n"
+          "  python add_hyphen_for_image_url.py E:\\github\\co-neco.github.io\\source\\_data\n\n")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        usage()
+        sys.exit(0)
+    main(sys.argv[1])

--- a/scripts/helpers/engine.js
+++ b/scripts/helpers/engine.js
@@ -118,12 +118,36 @@ hexo.extend.helper.register('_image_url', function(img, path = '') {
 hexo.extend.helper.register('_cover', function(item, num) {
   const { statics, js, image_server, image_list } = hexo.theme.config;
 
+  let image_list_filter = function (image_list) {
+    let image_list_by_day = [];
+    let day = new Date().getDate();
+
+    let get_image_day = function (image) {
+      let https_index = image.search(/https/)
+      let image_day = parseInt(image.substring(0, https_index), 10)
+      return image_day
+    }
+
+    let get_image_cluster_num = function (image_list) {
+      let last_image = image_list[image_list.length - 1]
+      return get_image_day(last_image)
+    }
+
+    let filter_day = (day % get_image_cluster_num(image_list)) + 1
+    for (let image of image_list) {
+      // image eg: "5https://gitee.com/co-neco/pic_bed/raw/master/cg%20(1149).jpg"
+      if (get_image_day(image) == filter_day)
+        image_list_by_day.push(image.substring(image.search(/https/)))
+    }
+    return image_list_by_day
+  }
+
   if(item.cover) {
     return this._image_url(item.cover, item.path)
   } else if (item.photos && item.photos.length > 0) {
     return this._image_url(item.photos[0], item.path)
   } else {
-    return randomBG(num || 1, image_server, image_list);
+    return randomBG(num || 1, image_server, image_list_filter(image_list));
   }
 
 })


### PR DESCRIPTION
1. 需求描述
我有几套图，一个是路人女主，一个是苍之彼方的四重奏等。我的需求是根据当前日期（每月的几号），展示某一套图。
2. 实现
修改engine.js对图库的获取：图库在传给randomBG方法前，根据当前日期过滤出某一套图，然后传给randomBG。
3. 使用
3.1 放入图片链接
在个人博客工程的source/_data/image_host目录下放入几套图的链接，每一套图用一个文件表示，举例如下：
saenai.txt：
https://tva4.sinaimg.cn/large/afc1d3e3ly8gt2oy0jlc8j20q611fn16.jpg
https://tva3.sinaimg.cn/large/afc1d3e3ly8gt2oy13xnsj20q60zzwk2.jpg
https://tva1.sinaimg.cn/large/afc1d3e3ly8gt2oy2q4dnj20q60zrwkw.jpg

---
aokana.txt:
https://gitee.com/co-neco/pic_bed/raw/master/cg%20(1196).jpg
https://gitee.com/co-neco/pic_bed/raw/master/cg%20(1180).jpg
https://gitee.com/co-neco/pic_bed/raw/master/cg%20(1179).jpg
---
注意以上链接不需要中划线
3.2 执行add_hyphen_for_image_url.py脚本
该脚本需要一个参数，就是source/_data/image_host目录的路径。
执行该脚本后，会生成一个source/_data/image.yml文件，该文件的形式如下：
# aokana.txt
https://gitee.com/co-neco/pic_bed/raw/master/cg%20(1196).jpg
https://gitee.com/co-neco/pic_bed/raw/master/cg%20(1180).jpg
https://gitee.com/co-neco/pic_bed/raw/master/cg%20(1179).jpg

# saenai.txt：
https://tva4.sinaimg.cn/large/afc1d3e3ly8gt2oy0jlc8j20q611fn16.jpg
https://tva3.sinaimg.cn/large/afc1d3e3ly8gt2oy13xnsj20q60zzwk2.jpg
https://tva1.sinaimg.cn/large/afc1d3e3ly8gt2oy2q4dnj20q60zrwkw.jpg

---
3.3 重启hexo的本地服务器
重启之后(hexo s --debug)，就能看到这两套图只会显示其中某一套。 



