### PR TITLE
feat: 增加 Google analytics 4 功能

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -277,6 +277,14 @@ baidu_site_verification:
 # Enable baidu push so that the blog will push the url to baidu automatically which is very helpful for SEO.
 baidu_push: false
 
+# Google Analytics 4
+# See: https://analytics.google.com/analytics/web/
+google_analytics:
+
+# Google Tags
+# See: https://tagmanager.google.com/
+google_tag:
+
 
 #! ---------------------------------------------------------------
 #! DO NOT EDIT THE FOLLOWING `vendors` SETTINGS

--- a/layout/_partials/layout.njk
+++ b/layout/_partials/layout.njk
@@ -5,11 +5,14 @@
 <!DOCTYPE html>
 <html lang="{{ page.language if page.language else config.language }}">
 <head>
+  {{ partial('_partials/third-party/google-analytics.njk', {}, {cache: true}) }}
+  {{ partial('_partials/third-party/google-tag-head.njk', {}, {cache: true}) }}
   {{ partial('_partials/head/head.njk', {}, {cache: true}) }}
   {{ partial('_partials/head/head_unique.njk') }}
   <title>{% block title %}{% endblock %}{{ alternate + " = " if alternate }}{{ title }}{{ " = "+subtitle if subtitle }}</title>
 </head>
 <body itemscope itemtype="http://schema.org/WebPage">
+  {{ partial('_partials/third-party/google-tag-body.njk', {}, {cache: true}) }}
   <div id="loading">
     <div class="cat">
       <div class="body"></div>

--- a/layout/_partials/third-party/google-analytics.njk
+++ b/layout/_partials/third-party/google-analytics.njk
@@ -1,0 +1,11 @@
+{%- if theme.google_analytics %}
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id={{ theme.google_analytics }}"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', '{{ theme.google_analytics }}');
+</script>
+{%- endif %}

--- a/layout/_partials/third-party/google-tag-body.njk
+++ b/layout/_partials/third-party/google-tag-body.njk
@@ -1,0 +1,6 @@
+{%- if theme.google_tag %}
+<!-- Google Tag Manager (noscript) -->
+<noscript><iframe src="https://www.googletagmanager.com/ns.html?id={{ theme.google_tag }}"
+height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+<!-- End Google Tag Manager (noscript) -->
+{%- endif%}

--- a/layout/_partials/third-party/google-tag-head.njk
+++ b/layout/_partials/third-party/google-tag-head.njk
@@ -1,0 +1,9 @@
+{%- if theme.google_tag %}
+<!-- Google Tag Manager -->
+<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','{{ theme.google_tag }}');</script>
+<!-- End Google Tag Manager -->
+{%- endif %}


### PR DESCRIPTION
`google_analytics` 為 google analytic 網頁串流的評估 ID
![image](https://user-images.githubusercontent.com/12424898/186709909-3f9f4997-d0d9-4dd7-b46a-8eed17316320.png)

`google_tag` 則為 GTag 頁面右上角的容器 ID
![image](https://user-images.githubusercontent.com/12424898/186710062-724b6bf0-be0a-43c8-8ff7-8e697d7edfbc.png)
